### PR TITLE
change finalise self.thruster_pulsewidth

### DIFF
--- a/PwmOut.py
+++ b/PwmOut.py
@@ -28,7 +28,7 @@ class PwmOut:
         self.pin_servo = pin_servo
         self.pin_thruster = pin_thruster
         self.servo_pulsewidth = 1500
-        self.thruster_pulsewidth = 1500
+        self.thruster_pulsewidth = 1100
         self.coefficient = 1.0
 
         # Setup for Out
@@ -36,7 +36,7 @@ class PwmOut:
         self.pi.set_mode(self.pin_servo, pigpio.OUTPUT)
         self.pi.set_mode(self.pin_thruster, pigpio.OUTPUT)
         self.pi.set_servo_pulsewidth(self.pin_servo, 1500) # neutral
-        self.pi.set_servo_pulsewidth(self.pin_thruster, 1500) # neutral
+        self.pi.set_servo_pulsewidth(self.pin_thruster, 1100) # neutral
         return
 
     # This function changes pulsewidth for weather. 
@@ -46,7 +46,7 @@ class PwmOut:
 
     def finalize(self):
         self.pi.set_servo_pulsewidth(self.pin_servo, 1500) # neutral
-        self.pi.set_servo_pulsewidth(self.pin_thruster, 1500) # neutral
+        self.pi.set_servo_pulsewidth(self.pin_thruster, 1100) # neutral
         return
 
     def updatePulsewidth(self):


### PR DESCRIPTION
`self.thruster_pulsewidth`のニュートラルが1100の設定になっているのですが、`finalize`が1500になっているので修正しました。
`__init__` 部分も同様だったので、変更して問題ないと感じたので、変更を加えています。（動作確認は、`finalize`変更した場合のみしかしていません）