### PR TITLE
fix judgement of OR mode

### DIFF
--- a/Driver.py
+++ b/Driver.py
@@ -114,7 +114,7 @@ class Driver:
         mode_duty_ratio = self.pwm_read.pulse_width[0]
         or_pulse = self.pwm_read.pulse_width[3]
         # OR mode
-        if or_pulse == 1100 or (1500 <= mode_duty_ratio and self.or_experienced):
+        if or_pulse < 1300 or (1500 <= mode_duty_ratio and self.or_experienced):
             if not self.or_experienced:
                 self.status.updateWayPoint()
             self.status.mode = "OR"


### PR DESCRIPTION
ORの判定方法が，

10回連続で1300未満だったならばOR，一度でも1300以上になったらRC（またばAN）に戻る

となる実装だったものを，

直近20回の平均が1300未満ならばOR，1300以上ならばRC（またばAN）

という実装に変更しました。
直近20回の値の保持にはQueueを使っています。

統計学的な有意性等は考慮していない簡易的な実装です。


This pull request automatically closes #24 