### PR TITLE
add message when python2 is used

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,6 @@
 #
 
 import sys
-import traceback
 
 
 def main():

--- a/main.py
+++ b/main.py
@@ -9,15 +9,24 @@
 #
 
 import sys
-from Driver import Driver
+import traceback
 
 
 def main():
     # confirm python3
     version_info = sys.version_info
-    assert version_info.major >= 3
+    try:
+        assert version_info.major >= 3
+    except AssertionError:
+        print("Use python3.")
+        print("Usage: python3 main.py [parameter_file]")
+        return
+
     # Initilize
+    from Driver import Driver
+
     driver = Driver()
+
     try:
         # Command line arguments
         args = sys.argv
@@ -29,7 +38,7 @@ def main():
         driver.doOperation()
     except InitialArgumentsError:
         print("[ERROR] NO ARGUMENTS")
-        print("Usage: python3 main.py (parameter_file)")
+        print("Usage: python3 main.py [parameter_file]")
     except KeyboardInterrupt:
         print("KeyboardInterrupt")
     finally:


### PR DESCRIPTION
python2で実行しようとしたときのエラーメッセージを追加しました。
main内でのDriverのimportを遅らせることで、エラーを分かりやすくしています。
以下のように終了します。
```bash
$ python2 main.py
Use python3.
Usage: python3 main.py [parameter_file]
```