### PR TITLE
import文の順序をPEP8に準拠

### DIFF
--- a/Driver.py
+++ b/Driver.py
@@ -8,18 +8,18 @@
 #   Author: Tetsuro Ninomiya
 #
 
-from TimeManager import TimeManager
-from Params import Params
-from Status import Status
+import json
+import sys
+import time
+
+from ina226 import ina226
 from Logger import Logger
+from Params import Params
+from Pid import PositionalPID
 from PwmOut import PwmOut
 from PwmRead import PwmRead
-from Pid import PositionalPID
-from ina226 import ina226
-import json
-
-import time
-import sys
+from Status import Status
+from TimeManager import TimeManager
 
 INA226_ADDRESS = 0x40
 

--- a/GpsData.py
+++ b/GpsData.py
@@ -8,10 +8,12 @@
 #   Author: Xu Guanglei
 #
 
-from serial import Serial
-from micropyGPS import MicropyGPS
 import threading
 import time
+
+from serial import Serial
+
+from micropyGPS import MicropyGPS
 
 
 class GpsData:

--- a/PwmOut.py
+++ b/PwmOut.py
@@ -8,8 +8,10 @@
 #   Author: FENG XUANDA
 #
 
-import pigpio
 import time
+
+import pigpio
+
 from Params import Params
 
 

--- a/PwmRead.py
+++ b/PwmRead.py
@@ -8,9 +8,10 @@
 #   Author: Tetsuro Ninomiya
 #
 
-import RPi.GPIO as GPIO
 import time
 from queue import Queue
+
+import RPi.GPIO as GPIO
 
 
 class PwmRead:

--- a/Status.py
+++ b/Status.py
@@ -8,11 +8,11 @@
 #   Author: Tetsuro Ninomiya
 #
 
+import math
+
+from GpsData import GpsData
 from Params import Params
 from Waypoint import Waypoint
-from GpsData import GpsData
-
-import math
 
 
 class Status:

--- a/ina226.py
+++ b/ina226.py
@@ -21,10 +21,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 
-import time
-import math
 import ctypes
+import math
 import sys
+import time
 
 PYTHON_SMBUS_LIB_PRESENT = True
 


### PR DESCRIPTION
PEP8に準拠するという方針にもかかわらずimport文の順番が準拠していなかったので修正しました。
https://pep8-ja.readthedocs.io/ja/latest/
上記のページでPEP8は以下のように言っています
> import文 は次の順番でグループ化すべきです:
> 
> 1. 標準ライブラリ
> 2. サードパーティに関連するもの
> 3. ローカルな アプリケーション/ライブラリ に特有のもの

import文をぱっと見した時に標準で入っているのか、pip等でimportする必要があるものなのか、自作なのかが分かるようにだと思います。

今使われているautoblackも設定をいじったら自動でやってくれるようにできる気はしますが面倒なので手をつけていないです。
僕はvscodeの拡張機能でコードを保存するタイミングで自動的にimportの順番を含めてPEP8に準拠するようにformatしてくれるようにしています。