### PR TITLE
readの条件の変更

### DIFF
--- a/GpsData.py
+++ b/GpsData.py
@@ -61,7 +61,7 @@ class GpsData:
 
     def read(self):
         try:
-            if self.gps.clean_sentences > 20:
+            if self.gps.parsed_sentences > 0:
                 h = (
                     self.gps.timestamp[0]
                     if self.gps.timestamp[0] < 24


### PR DESCRIPTION
MicropyGPSの[コード](https://github.com/inmcm/micropyGPS)を確認したところ、`clean_sentences`が20行以上たまるまで待つ理由がなさそうだったので変更しました。
`parsed_sentences > 0`の条件で正しい位置情報が一度以上取れていることが保証されていると思います